### PR TITLE
mainnet

### DIFF
--- a/docs/dapp-development/mainnet.md
+++ b/docs/dapp-development/mainnet.md
@@ -52,20 +52,20 @@ Léase más sobre estos métodos [aquí](./rpc/README.md).
 
 ### En inglés
 
-1. [Installation](https://github.com/nebulasio/wiki/blob/master/tutorials/[English]%20Nebulas%20101%20-%2001%20Installation.md) \(thanks [Victor](https://github.com/victorychain)\)
-2. [Sending a Transaction](https://github.com/nebulasio/wiki/blob/master/tutorials/[English]%20Nebulas%20101%20-%2002%20Transaction.md) \(thanks [Victor](https://github.com/victorychain)\)
-3. [Writing Smart Contract in JavaScript](https://github.com/nebulasio/wiki/blob/master/tutorials/[English]%20Nebulas%20101%20-%2003%20Smart%20Contracts%20JavaScript.md) \(thanks [otto](https://github.com/ottokafka)\)
-4. [Introducing Smart Contract Storage](https://github.com/nebulasio/wiki/blob/master/tutorials/[English]%20Nebulas%20101%20-%2004%20Smart%20Contract%20Storage.md) \(thanks [Victor](https://github.com/victorychain)\)
-5. [Interacting with Nebulas by RPC API](https://github.com/nebulasio/wiki/blob/master/tutorials/[English]%20Nebulas%20101%20-%2005%20Interacting%20with%20Nebulas%20by%20RPC%20API.md) \(thanks [Victor](https://github.com/victorychain)\)
+1. [Instalación](https://github.com/nebulasio/wiki/blob/master/tutorials/%5BEnglish%5D%20Nebulas%20101%20-%2001%20Installation.md), (contribución de [Victor](https://github.com/victorychain)).
+1. [Cómo enviar una transacción](https://github.com/nebulasio/wiki/blob/master/tutorials/%5BEnglish%5D%20Nebulas%20101%20-%2002%20Transaction.md), (contribución de [Victor](https://github.com/victorychain)).
+1. [Cómo escribir un contrato inteligente en Javascript](https://github.com/nebulasio/wiki/blob/master/tutorials/%5BEnglish%5D%20Nebulas%20101%20-%2003%20Smart%20Contracts%20JavaScript.md), (contribución de [otto](https://github.com/ottokafka)).
+1. [Introducción al almacenamiento de contratos inteligentes](https://github.com/nebulasio/wiki/blob/master/tutorials/%5BEnglish%5D%20Nebulas%20101%20-%2004%20Smart%20Contract%20Storage.md), (contribución de [Victor](https://github.com/victorychain)).
+1. [Interacción con Nebulas por medio de la API RPC](https://github.com/nebulasio/wiki/blob/master/tutorials/%5BEnglish%5D%20Nebulas%20101%20-%2005%20Interacting%20with%20Nebulas%20by%20RPC%20API.md), (contribución de [Victor](https://github.com/victorychain)).
 
 ### 中文
 
-1. [编译安装及运行neb](https://github.com/nebulasio/wiki/blob/master/tutorials/[中文]%20Nebulas%20101%20-%2001%20编译安装.md)
-2. [在星云链上发送交易](https://github.com/nebulasio/wiki/blob/master/tutorials/[中文]%20Nebulas%20101%20-%2002%20发送交易.md)
-3. [使用JavaScript编写智能合约](https://github.com/nebulasio/wiki/blob/master/tutorials/[中文]%20Nebulas%20101%20-%2003%20编写智能合约.md)
-4. [智能合约存储区介绍](https://github.com/nebulasio/wiki/blob/master/tutorials/[中文]%20Nebulas%20101%20-%2004%20智能合约存储区.md)
-5. [通过RPC接口与星云链交互](https://github.com/nebulasio/wiki/blob/master/tutorials/[中文]%20Nebulas%20101%20-%2005%20通过RPC接口与星云链交互.md)
+1. [编译安装及运行neb](https://github.com/nebulasio/wiki/blob/master/tutorials/%5B中文%5D%20Nebulas%20101%20-%2001%20编译安装.md).
+1. [在星云链上发送交易](https://github.com/nebulasio/wiki/blob/master/tutorials/%5B中文%5D%20Nebulas%20101%20-%2002%20发送交易.md).
+1. [使用JavaScript编写智能合约](https://github.com/nebulasio/wiki/blob/master/tutorials/%5B中文%5D%20Nebulas%20101%20-%2003%20编写智能合约.md)
+1. [智能合约存储区介绍](https://github.com/nebulasio/wiki/blob/master/tutorials/%5B中文%5D%20Nebulas%20101%20-%2004%20智能合约存储区.md).
+1. [通过RPC接口与星云链交互](https://github.com/nebulasio/wiki/blob/master/tutorials/%5B中文%5D%20Nebulas%20101%20-%2005%20通过RPC接口与星云链交互.md).
 
-## Contribution
+## Cómo contribuir
 
-Feel free to join the Nebulas Mainnet. If you have found something wrong, please [submit an issue](https://github.com/nebulasio/go-nebulas/issues/new) or [submit a pull request](https://github.com/nebulasio/go-nebulas/pulls) to let us know, and we will add your name and url to this page as soon as possible.
+¡Siéntete libre de unirte a la Mainnet de Nebulas! Si has encontrado un error, por favor [envía un aviso](https://github.com/nebulasio/go-nebulas/issues/new), o si eres desarrollador, [crea un pull request](https://github.com/nebulasio/go-nebulas/pulls); de ese modo podremos corregir los errores o añadir tu contribución a esta página lo antes posible.

--- a/docs/dapp-development/mainnet.md
+++ b/docs/dapp-development/mainnet.md
@@ -1,58 +1,56 @@
-# How to Join Nebulas Mainnet
+# Cómo unirse a la mainnet de Nebulas
 
-## Introduction
+## Código fuente
 
-We are glad to release Nebulas Mainnet here. Please join and enjoy Nebulas Mainnet.
+Puedes encontrar el código fuente de la mainnet de Nebulas en [nuestro repositorio github](https://github.com/nebulasio/go-nebulas/tree/master).
 
-```text
-https://github.com/nebulasio/go-nebulas/tree/master
-```
+## Configuración
 
-### Configuration
+Podrás encontrar los archivos de configuración de la mainnet en [`mainnet/conf`](https://github.com/nebulasio/go-nebulas/tree/master/mainnet/conf).
 
-The Mainnet configuration files are in folder [`mainnet/conf`](https://github.com/nebulasio/go-nebulas/tree/master/mainnet/conf), including
+Esa carpeta contiene los siguientes archivos:
 
 ### genesis.conf
 
-All configurable information about genesis block is defined in genesis.conf, including
+Permite configurar los parámetros del bloque inicial (_genesis block_), incluyendo:
 
-* **meta.chain\_id:** chain identity
-* **consensus.dpos.dynasty:** the initial dynasty of validators
-* **token\_distribution:** the initial allocation of tokens
+* **meta.chain\_id**: Identidad de la cadena.
+* **consensus.dpos.dynasty**: Dinastía inicial de validadores.
+* **token\_distribution**: Asignación inicial de tokens.
 
-> _Attention_: DO NOT change the genesis.conf.
+> **IMPORTANTE**: No se deben realizar cambios sobre el archivo genesis.conf.
 
 ### config.conf
 
-All configurable information about runtime is defined in config.conf.
+Permite configurar los parámetros del runtime.
 
-Please check the [`template.conf`](https://github.com/smalloranges/wiki/tree/887270957eb99d971309610bc1fdafb6a2d9d552/resources/conf/template.conf) to find more details about the runtime configuration.
+Para más información sobre este archivo, véase [`template.conf`](https://github.com/smalloranges/wiki/tree/887270957eb99d971309610bc1fdafb6a2d9d552/resources/conf/template.conf).
 
-> _Tips_: the official seed node info is as below,
+> **Nota**: la información del nodo semilla oficial debe verse tal como se muestra aquí debajo:
 
 ```javascript
 seed:["/ip4/52.2.205.12/tcp/8680/ipfs/QmQK7W8wrByJ6So7rf84sZzKBxMYmc1i4a7JZsne93ysz5","/ip4/52.56.55.238/tcp/8680/ipfs/QmVy9AHxBpd1iTvECDR7fvdZnqXeDhnxkZJrKsyuHNYKAh","/ip4/13.251.33.39/tcp/8680/ipfs/QmVm5CECJdPAHmzJWN2X7tP335L5LguGb9QLQ78riA9gw3"]
 ```
 
-### API List
+## Resumen de la API
 
-Main Endpoint:
+Endpoint principal:
 
-| API | URL | Protocol |
+| API | URL | Protocolo |
 | --- | :---: | :---: |
 | RESTful | [https://mainnet.nebulas.io/](https://mainnet.nebulas.io/) | HTTP |
 
-* [GetNebState](https://github.com/nebulasio/wiki/blob/master/rpc.md#getnebstate) : returns nebulas client info.
-* [GetAccountState](https://github.com/nebulasio/wiki/blob/master/rpc.md#getaccountstate): returns the account balance and nonce.
-* [Call](https://github.com/nebulasio/wiki/blob/master/rpc.md#call): execute smart contract local, don't submit on chain.
-* [SendRawTransaction](https://github.com/nebulasio/wiki/blob/master/rpc.md#sendrawtransaction): submit the signed transaction.
-* [GetTransactionReceipt](https://github.com/nebulasio/wiki/blob/master/rpc.md#gettransactionreceipt): get transaction receipt info by tansaction hash.
+* [GetNebState](./rpc/README.md#getnebstate): Devuelve información sobre el cliente.
+* [GetAccountState](./rpc/README.md#getaccountstate): Devuelve el balance y el _nonce_ de la cuenta.
+* [Call](./rpc/README.md#call): Ejecuta un contrato inteligente de forma local, sin enviar datos al chain.
+* [SendRawTransaction](./rpc/README.md#sendrawtransaction): Permite enviar una transacción firmada.
+* [GetTransactionReceipt](./rpc/README.md#gettransactionreceipt): Obtiene información del recibo de una transacción mediante su hash.
 
-More Nebulas APIs at [RPC](https://github.com/nebulasio/wiki/blob/master/rpc.md).
+Léase más sobre estos métodos [aquí](./rpc/README.md).
 
-## Tutorials
+## Tutoriales
 
-### English
+### En inglés
 
 1. [Installation](https://github.com/nebulasio/wiki/blob/master/tutorials/[English]%20Nebulas%20101%20-%2001%20Installation.md) \(thanks [Victor](https://github.com/victorychain)\)
 2. [Sending a Transaction](https://github.com/nebulasio/wiki/blob/master/tutorials/[English]%20Nebulas%20101%20-%2002%20Transaction.md) \(thanks [Victor](https://github.com/victorychain)\)
@@ -71,4 +69,3 @@ More Nebulas APIs at [RPC](https://github.com/nebulasio/wiki/blob/master/rpc.md)
 ## Contribution
 
 Feel free to join the Nebulas Mainnet. If you have found something wrong, please [submit an issue](https://github.com/nebulasio/go-nebulas/issues/new) or [submit a pull request](https://github.com/nebulasio/go-nebulas/pulls) to let us know, and we will add your name and url to this page as soon as possible.
-


### PR DESCRIPTION
**Notice** that several links on the bottom (Chinese ones) aren't working. I fixed the links to English tutorials, but as I don't speak Chinese, I'm somewhat lost with those for that language.

I figured out the issue was on the non-escaped use of brackets inside links. You must use the URL-encoded version (for example, a space (``` ```) is converted to ```%20```).

If you fix it, let me know so I can fix the ones in this file.

Thanks!